### PR TITLE
added proxy for api but still issues with it

### DIFF
--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -5,7 +5,7 @@ import axios from "axios";
 import { auth } from "../firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
-const API_URL = "http://127.0.0.1:8080/api/stories";
+const API_URL = "/api/stories"; // proxy handles forwarding to port 8080
 
 function Upload() {
   const [file, setFile] = useState(null);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,4 +8,14 @@ export default defineConfig({
     react(),
     tailwindcss()
   ],
+  server: {
+    proxy: {
+      // any request starting with /api will be forwarded to your backend
+      '/api': {
+        target: 'http://127.0.0.1:8080',
+        changeOrigin: true,
+        secure: false,
+      }
+    }
+  }
 })


### PR DESCRIPTION
10:09:24 AM [vite] http proxy error: /api/stories
Error: connect ECONNREFUSED 127.0.0.1:8080
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)

It uploads to Firebase ,but it says it fails on top

Also when uploading you must be login or it won't let you upload 
And when you upload it, it saves in the storage and makes a new folder for that user's upload.